### PR TITLE
Docs on triggers and separation of concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ reliable CI processes.
 
 *Work in progress* (https://github.com/Cambridge-ICCS/green-ci/issues/3)
 
-### Triggers and separation of concerns
+### Triggers
 
 Suppose you want to make a small change such as fixing typos or updating
 Markdown files. In a naive CI setup, this will trigger the full suite, involving
@@ -60,7 +60,7 @@ trigger the test suite when they are run. For example, in Python we could use:
 name: MyPythonTestSuite
 
 on:
-  # Triggers the workflow on pushes to open pull requests
+  # Triggers the workflow on pushes to open pull requests with code changes
   pull_request:
     paths:
       - '.github/workflows/test_suite_python.yml'
@@ -77,7 +77,7 @@ files related to the build system. For example:
 name: MyCTestSuite
 
 on:
-  # Triggers the workflow on pushes to open pull requests
+  # Triggers the workflow on pushes to open pull requests with code changes
   pull_request:
     paths:
       - '.github/workflows/test_suite_c.yml'
@@ -87,6 +87,56 @@ on:
 ```
 for source code with extension `.c`, header files with extension `.h`, and CMake
 build files.
+
+### Separation of concerns
+
+The information on [triggers](#triggers) above is useful but what if you have
+workflows for other tasks than just tests, such as static analysis and
+documentation builds? In such cases, it's good practice to implement separate
+workflows with appropriate triggers.
+
+In the example case of a Python code that uses the
+[ruff](https://docs.astral.sh/ruff/) static analysis tool for linting and
+formatting, the triggers could take the form:
+```yml
+name: MyPythonStaticAnalysisWorkflow
+
+on:
+  # Triggers the workflow on pushes to open pull requests with code changes
+  pull_request:
+    paths:
+      - '.github/workflows/static_analysis_python.yml'
+      - '**.py'
+```
+where `static_analysis_python.yml` is the filename of the workflow. Here, the
+workflow will only be triggered when commits are pushed that include changes to
+the workflow configuration or Python source code.
+
+In the example case where Fortran documentation is built using
+[FORD](https://github.com/Fortran-FOSS-Programmers/ford), the triggers could
+take the form:
+```yml
+name: BuildDocs
+
+on:
+  # Triggers the workflow on pushes to open pull requests to main with documentation changes
+  pull_request:
+    paths:
+      - '.github/workflows/build_docs_ford.yml'
+      - '**.md'
+      - 'pages/*'
+```
+
+The above can be extended to separate out CPU vs. GPU test suites, test suites
+on different operating systems (e.g., Ubuntu, Mac, Windows), and
+[JOSS](https://joss.theoj.org/) paper rendering, for example. Having separated
+concerns in this way, the overall number of jobs can be reduced, provided the
+contributor doesn't modify several different parts of the repository in the same
+change.
+
+> [!NOTE] In some cases it can be a good thing for contributors to edit multiple
+>         different types of files in the same change. For example, it is good
+>         practice to update documentation in line with changes to source code.
 
 ### Test PRs
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,29 @@ reliable CI processes.
 
 ### Triggers and separation of concerns
 
-*Work in progress* (https://github.com/Cambridge-ICCS/green-ci/issues/4)
+Suppose you want to make a small change such as fixing typos or updating
+Markdown files. In a naive CI setup, this will trigger the full suite, involving
+tasks such as running tests, building documentation, and running static analysis
+tools. This can be extremely wasteful, especially for large repositories with
+long-running test suites. One way to avoid this is to make use of *triggers*.
+You might be familiar with triggers related to pushing to particular branches,
+pushes to open PRs, and manual triggering from the
+[Actions](https://github.com/Cambridge-ICCS/green-ci/actions) tab, as
+demonstrated below:
+```yml
+name: MyTestSuite
+
+on:
+  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  push:
+    branches: [ "main" ]
+
+  # Triggers the workflow on pushes to open pull requests
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+```
 
 ### Test PRs
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,45 @@ on:
   workflow_dispatch:
 ```
 
+In the following, we restrict attention to `pull_request` triggers because it
+usually makes sense to run the full workflow when merging into `main` and the
+`workflow_dispatch` option already allows for finer-grained control over
+specific jobs. Returning to the case of updating a Markdown file, the test suite
+above will still run if a commit is pushed to an open PR doing so. To avoid this
+unnecessary test run, we can specify a list of `paths` for files that would
+trigger the test suite when they are run. For example, in Python we could use:
+```yml
+name: MyPythonTestSuite
+
+on:
+  # Triggers the workflow on pushes to open pull requests
+  pull_request:
+    paths:
+      - '.github/workflows/test_suite_python.yml'
+      - '**.py'
+      - 'requirements.txt'
+```
+where `test_suite_python.yml` is the name of the workflow file itself. Here the
+workflow will only be run if the file itself, any Python source files, or the
+repository's `requirements.txt` dependencies file change.
+
+For compiled languages such as C, it would likely also be a good idea to include
+files related to the build system. For example:
+```yml
+name: MyCTestSuite
+
+on:
+  # Triggers the workflow on pushes to open pull requests
+  pull_request:
+    paths:
+      - '.github/workflows/test_suite_c.yml'
+      - '**.c'
+      - '**.h'
+      - '**CMakeLists.txt'
+```
+for source code with extension `.c`, header files with extension `.h`, and CMake
+build files.
+
 ### Test PRs
 
 *Work in progress* (https://github.com/Cambridge-ICCS/green-ci/issues/5)


### PR DESCRIPTION
Closes #4.

This PR completes the docs section on triggers, with some examples. I ended up adding the docs on separation of concerns as a separate section.