### PR TITLE
docs: Add note about get-measurement

### DIFF
--- a/template/.github/workflows/build_docs.yml.jinja
+++ b/template/.github/workflows/build_docs.yml.jinja
@@ -40,11 +40,26 @@ jobs:
         continue-on-error: true
 
       # TODO: Add your other steps here
+    
+      # NOTE: To measure energy consumption of specific steps in your workflow,
+      # For each step you want to measure, add a measurement step after it with a unique label
+      # this will allow the eco-ci tool to collect energy consumption data. Example below.
+      # See https://github.com/green-coding-solutions/eco-ci-energy-estimation?tab=readme-ov-file#github-action-mandatory-and-optional-variables
+      #   - name: Tests measurement
+      #     uses: green-coding-solutions/eco-ci-energy-estimation@v4 # use hash or @vX here (See note below)
+      #     with:
+      #       task: get-measurement
+      #       label: 'pytest'
+      #     continue-on-error: true
 
       - name: Show Energy Results
         uses: green-coding-solutions/eco-ci-energy-estimation@v4 # use hash or @vX here (See note below)
         with:
           task: display-results
         continue-on-error: true
+      {% endraw %}
+      {% else %}
+      {% raw %}
+      # TODO: Add your other steps here
       {% endraw %}
       {%- endif -%}


### PR DESCRIPTION
This pull request updates the `build_docs.yml.jinja` GitHub Actions workflow template to provide guidance on measuring energy consumption for specific workflow steps using the eco-ci tool. The main change is the addition of commented instructions and an example for integrating energy measurement steps.

Documentation and workflow configuration:

* Added commented instructions and an example step showing how to measure energy consumption for individual workflow steps using the `eco-ci-energy-estimation` GitHub Action, including a link to the relevant documentation.

---

Related issue: #32 