### PR TITLE
Create a GreenCI badge users can put in their repo

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -70,4 +70,9 @@ carbon_aware:
   default: true
   help: Whether to include carbon-aware energy measurement steps in the workflow
 
+include_badge:
+  type: bool
+  default: true
+  help: Whether to include a green-ci badge in the README.
+
 _subdirectory: "template"

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,0 +1,25 @@
+# <PACKAGE NAME>
+{% if include_badge %}
+![Static Badge](https://img.shields.io/badge/Templated_using-GreenCI-brightgreen?link=https%3A%2F%2Fgithub.com%2FCambridge-ICCS%2Fgreen-ci%2F)
+{% endif %}
+
+<!-- TODO: Repo summary -->
+
+## Table of Contents
+
+* [Description](#description)
+* [Usage](#usage)
+* [Repository structure](#repository-structure)
+* [Contributing](#contributing)
+
+## Usage
+
+<!-- TODO -->
+
+## Repository structure
+
+<!-- TODO -->
+
+## Contributing
+
+<!-- TODO -->

--- a/template/README.md.template
+++ b/template/README.md.template
@@ -1,1 +1,0 @@
-![Static Badge](https://img.shields.io/badge/Templated_using-GreenCI-brightgreen?link=https%3A%2F%2Fgithub.com%2FCambridge-ICCS%2Fgreen-ci%2F)


### PR DESCRIPTION
Closes #39.

If the repo has no README then one could be created as part of the templating, including the badge. If a `README` or `README.md` (etc) already exists then we could print a message to tell the user how to use the badge.