### PR TITLE
Use path triggers for branches, too

### DIFF
--- a/template/.github/workflows/build_docs.yml.jinja
+++ b/template/.github/workflows/build_docs.yml.jinja
@@ -6,6 +6,9 @@ on:
   # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
   push:
     branches: [ "main" ]
+    paths:
+      - '.github/workflows/build_docs.yml'{% for trigger in docs_file_paths %}
+      - '{{ trigger | safe }}'{% endfor %}
 
   # Triggers the workflow on pushes to open pull requests to main with documentation changes
   pull_request:

--- a/template/.github/workflows/render_joss_paper.yml.jinja
+++ b/template/.github/workflows/render_joss_paper.yml.jinja
@@ -6,6 +6,9 @@ on:
   # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
   push:
     branches: [ "main" ]
+    paths:
+      - '.github/workflows/render_joss_paper.yml'
+      - 'paper/*'
 
   # Triggers the workflow on pushes to open pull requests to main with documentation changes
   pull_request:

--- a/template/.github/workflows/static_analysis.yml.jinja
+++ b/template/.github/workflows/static_analysis.yml.jinja
@@ -6,6 +6,9 @@ on:
   # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
   push:
     branches: [ "main" ]
+    paths:
+      - '.github/workflows/*.yml'{% for trigger in source_file_paths %}
+      - '{{ trigger | safe }}'{% endfor %}
 
   # Triggers the workflow on pushes to open pull requests to main with documentation changes
   pull_request:

--- a/template/.github/workflows/test_suite.yml.jinja
+++ b/template/.github/workflows/test_suite.yml.jinja
@@ -6,6 +6,11 @@ on:
   # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
   push:
     branches: [ "main" ]
+    paths:
+      - '.github/workflows/test_suite.yml'{% for trigger in source_file_paths %}
+      - '{{ trigger | safe }}'{% endfor %}{% for trigger in build_sys_file_paths %}
+      - '{{ trigger | safe }}'{% endfor %}{% for trigger in requirements_file_paths %}
+      - '{{ trigger | safe }}'{% endfor %}
 
   # Triggers the workflow on pushes to open pull requests to main with documentation changes
   pull_request:


### PR DESCRIPTION
Closes #51

From the issue:
> Currently we only use path-based triggers when pushing to an open PR. We should do the same for branch-based triggers, too.