### PR TITLE
Link to GitHub repo from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,9 @@ developers can reduce the carbon footprint of their work and contribute to
 environmentally friendly software engineering while maintaining efficient and
 reliable CI/CD processes.
 
+The ``green-ci`` tool can be found on GitHub at
+https://github.com/Cambridge-ICCS/green-ci.
+
 Contents
 ^^^^^^^^
 


### PR DESCRIPTION
I shared the green-ci webpage with someone yesterday and just realised it doesn't actually link back to the repo!